### PR TITLE
Added verbosity and throughput to modelStats

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -177,6 +177,14 @@ export type ModelStats = {
   max_latency?: number
   avg_latency?: number
   median_latency?: number
+  min_throughput?: number
+  max_throughput?: number
+  avg_throughput?: number
+  median_throughput?: number
+  min_verbosity?: number
+  max_verbosity?: number
+  avg_verbosity?: number
+  median_verbosity?: number
   calculation_date: string
 }
 


### PR DESCRIPTION
Adding this to display verbosity and throughput on the front end for users. This is apart of https://github.com/EquiStamp/equistamp/issues/729 and related to https://github.com/EquiStamp/equistamp/pull/731